### PR TITLE
Ability to find tile in grid by world point.

### DIFF
--- a/Assets/ScriptableObjects/Grid/FaratharsHallGridData.asset
+++ b/Assets/ScriptableObjects/Grid/FaratharsHallGridData.asset
@@ -14,3 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: UnityEngine.CoreModule:UnityEngine:ScriptableObject
   numTilesX: 20
   numTilesY: 20
+  centeredAtWorldZero: 1
+  originWorldPosition: {x: 0, y: 0}

--- a/Assets/Scripts/Grid/Axis.cs
+++ b/Assets/Scripts/Grid/Axis.cs
@@ -1,0 +1,10 @@
+
+namespace Grid {
+    /// <summary>
+    /// Defines the 2 axis in a 2d grid.
+    /// </summary>
+    public enum Axis {
+        X,
+        Y
+    }
+}

--- a/Assets/Scripts/Grid/Axis.cs.meta
+++ b/Assets/Scripts/Grid/Axis.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23f97e14da67f41c4abe9fdf2b7ffed6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Grid/Grid.cs
+++ b/Assets/Scripts/Grid/Grid.cs
@@ -29,16 +29,18 @@ namespace Grid {
             }
         }
 
-        private Rect _worldSpaceBounds = Rect.zero;
-        public Rect WorldSpaceBounds {
+        private Vector2 _originWorldPosition;
+        public Vector2 OriginWorldPosition {
             get {
-                return _worldSpaceBounds;
+                return _originWorldPosition;
             }
         }
 
         public void LoadGridData(IGridData gridData) {
             _numTilesX = System.Math.Max(1, gridData.NumTilesX);
             _numTilesY = System.Math.Max(1, gridData.NumTilesY);
+            _originWorldPosition = gridData.OriginWorldPosition ??
+                                   new Vector2(-_numTilesX * TileSize / 2.0f, -_numTilesY * TileSize / 2.0f);
         }
     }
 }

--- a/Assets/Scripts/Grid/IGrid.cs
+++ b/Assets/Scripts/Grid/IGrid.cs
@@ -33,6 +33,10 @@ namespace Grid {
         /// </summary>
         uint TileSize { get; }
         /// <summary>
+        /// The world position corresponding to the (0,0) coordinate of the grid.
+        /// </summary>
+        Vector2 OriginWorldPosition { get; }
+        /// <summary>
         /// Loads the given <see cref="GridData"/>, setting values like grid dimensions.
         /// </summary>
         /// <param name="data"></param>
@@ -44,8 +48,8 @@ namespace Grid {
         /// The bounds of the rectangle containing this grid, in Unity World Space coordinates.
         /// </summary>
         public static Rect WorldSpaceBounds(this IGrid grid) {
-            return new Rect(-grid.TileSize * grid.NumTilesX / 2.0f,
-                            -grid.TileSize * grid.NumTilesY / 2.0f,
+            return new Rect(grid.OriginWorldPosition.x,
+                            grid.OriginWorldPosition.y,
                             grid.NumTilesX * grid.TileSize,
                             grid.NumTilesY * grid.TileSize);
         }

--- a/Assets/Scripts/Grid/Positioning/GridPositionCalculator.cs
+++ b/Assets/Scripts/Grid/Positioning/GridPositionCalculator.cs
@@ -38,7 +38,9 @@ namespace Grid.Positioning {
          */
         private int GetTileContainingWorldPosition(IGrid grid, float worldPosition, Axis axis, uint start,
                                                    uint end) {
-            if (worldPosition < start || worldPosition > end) {
+            float startWorldPosition = GetTileOriginWorldPosition(grid, start, axis);
+            float endWorldPosition = GetTileOriginWorldPosition(grid, end, axis);
+            if (worldPosition < startWorldPosition || worldPosition > endWorldPosition) {
                 return -1;
             }
 

--- a/Assets/Scripts/Grid/Positioning/GridPositionCalculator.cs
+++ b/Assets/Scripts/Grid/Positioning/GridPositionCalculator.cs
@@ -1,15 +1,10 @@
 
+using Math;
 using UnityEngine;
 
 namespace Grid.Positioning {
     public class GridPositionCalculator : IGridPositionCalculator {
-        /// <summary>
-        /// Gets the World position of the tile at the given x and y position in the grid.
-        /// </summary>
-        /// <param name="grid"></param>
-        /// <param name="x"></param>
-        /// <param name="y"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public Vector2 GetTileCenterWorldPosition(IGrid grid, int x, int y) {
             float xPosition = grid.WorldSpaceBounds().x + grid.TileSize / 2.0f + grid.TileSize * x;
             float yPosition = grid.WorldSpaceBounds().y + grid.TileSize / 2.0f + grid.TileSize * y;
@@ -17,26 +12,62 @@ namespace Grid.Positioning {
             return new Vector2(xPosition, yPosition);
         }
 
-        /**
-         * Returns the tile that is closest to the center of the grid.
-         * In the case where the grid is not of odd width (x axis), the tile X returned is the one left of the center position.
-         * In the case where the grid is not of odd height (y axis), the tile Y returned is the one bottom of the center position.
-         * i.e (o is returned)
-         *
-         * x x x
-         * x o x
-         * x x x
-         *
-         * e.g 2:
-         *
-         * x x x x
-         * x o x x
-         * 
-         */
+        /// <inheritdoc />
         public Vector2 GetTileClosestToCenter(IGrid grid) {
             uint xTile = grid.NumTilesX / 2;
             uint yTile = grid.NumTilesX / 2;
             return new Vector2(xTile, yTile);
+        }
+
+        /// <inheritdoc />
+        public IntVector2? GetTileContainingWorldPosition(IGrid grid, Vector2 worldPosition) {
+            int x = GetTileContainingWorldPosition(grid, worldPosition.x, Axis.X, 0, grid.NumTilesX);
+            int y = GetTileContainingWorldPosition(grid, worldPosition.y, Axis.Y, 0, grid.NumTilesY);
+            if (x == -1 || y == -1) {
+                return null;
+            }
+            
+            return IntVector2.Of(x, y);
+        }
+
+        /**
+         * Recursive method that binary searches the grid in order to find the given world position
+         * in the given axis.
+         *
+         * Returns -1 if the given worldPosition is not contained in the given axis of the grid.
+         */
+        private int GetTileContainingWorldPosition(IGrid grid, float worldPosition, Axis axis, uint start,
+                                                   uint end) {
+            if (worldPosition < start || worldPosition > end) {
+                return -1;
+            }
+
+            if (end <= start) {
+                return -1;
+            }
+
+            if (end == start + 1) {
+                return (int)start;
+            }
+
+            uint m = (start + end) / 2;
+            float middleWorldPosition = GetTileOriginWorldPosition(grid, m, axis);
+            if (worldPosition >= middleWorldPosition) {
+                return GetTileContainingWorldPosition(grid, worldPosition, axis, m, end);
+            } else {
+                return GetTileContainingWorldPosition(grid, worldPosition, axis, start, m);
+            }
+        }
+
+        /**
+         * Helper method to obtain the world position at the tile origin (minx, miny)
+         */
+        private float GetTileOriginWorldPosition(IGrid grid, uint coordinate, Axis axis) {
+            if (axis == Axis.X) {
+                return grid.WorldSpaceBounds().x + grid.TileSize * coordinate;
+            } else {
+                return grid.WorldSpaceBounds().y + grid.TileSize * coordinate;
+            }
         }
     }
 }

--- a/Assets/Scripts/Grid/Positioning/IGridPositionCalculator.cs
+++ b/Assets/Scripts/Grid/Positioning/IGridPositionCalculator.cs
@@ -1,4 +1,5 @@
 
+using Math;
 using UnityEngine;
 
 namespace Grid.Positioning {
@@ -29,5 +30,14 @@ namespace Grid.Positioning {
          * 
          */
         Vector2 GetTileClosestToCenter(IGrid grid);
+
+        /// <summary>
+        /// Gets the tile (if any) containing the given world position.
+        /// Returns null if the given worldPosition is not contained in the grid.
+        /// </summary>
+        /// <param name="grid"></param>
+        /// <param name="worldPosition"></param>
+        /// <returns></returns>
+        IntVector2? GetTileContainingWorldPosition(IGrid grid, Vector2 worldPosition);
     }
 }

--- a/Assets/Scripts/Grid/Positioning/Tests/GridPositionCalculatorTest.cs
+++ b/Assets/Scripts/Grid/Positioning/Tests/GridPositionCalculatorTest.cs
@@ -27,6 +27,25 @@ namespace Grid.Positioning.Tests {
             Assert.AreEqual(IntVector2.Of(expectedCoordX, expectedCoordY), position);
         }
         
+        [TestCase(1.0f, 1.0f, 4U, 4U, 3.99f, 3.99f, 2, 2)]
+        [TestCase(-1.0f, -2.5f, 4U, 4U, 0.01f, 0.01f, 1, 2)]
+        [TestCase(1.25f, 1.50f, 1U, 1U, 1.51f, 1.51f, 0, 0)]
+        public void TestGivenTileInGrid_OriginWorldPositionSet_GetTileContainingWorldPosition_ReturnsCoordinate(
+            float worldPositionX, float worldPositionY,
+            uint numTilesX, uint numTilesY, float x, float y, int expectedCoordX, int expectedCoordY) {
+            IGrid grid = Substitute.For<IGrid>();
+            grid.NumTilesX.Returns(numTilesX);
+            grid.NumTilesY.Returns(numTilesY);
+            grid.TileSize.Returns((uint)1);
+            grid.OriginWorldPosition.Returns(new Vector2(worldPositionX, worldPositionY));
+            
+            IGridPositionCalculator gridPositionCalculator = new GridPositionCalculator();
+            IntVector2? position = gridPositionCalculator.GetTileContainingWorldPosition(grid, new Vector2(x, y));
+            Assert.NotNull(position);
+            Assert.AreEqual(IntVector2.Of(expectedCoordX, expectedCoordY), position);
+        }
+        
+        
         [TestCase(4U, 4U, 4.01f, 4.01f)]
         [TestCase(4U, 4U, -0.01f, -0.01f)]
         [TestCase(1U, 1U, 1.01f, 1.01f)]

--- a/Assets/Scripts/Grid/Positioning/Tests/GridPositionCalculatorTest.cs
+++ b/Assets/Scripts/Grid/Positioning/Tests/GridPositionCalculatorTest.cs
@@ -1,0 +1,46 @@
+using Math;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Grid.Positioning.Tests {
+    [TestFixture]
+    public class GridPositionCalculatorTest {
+        [TestCase(4U, 4U, 3.99f, 3.99f, 3, 3)]
+        [TestCase(4U, 4U, 0.01f, 0.01f, 0, 0)]
+        [TestCase(1U, 1U, 0.99f, 0.99f, 0, 0)]
+        [TestCase(1U, 1U, 0.01f, 0.01f, 0, 0)]
+        [TestCase(63U, 23U, 5.0001f, 22.5f, 5, 22)]
+        [TestCase(2U, 2U, 1.00001f, 1.0001f, 1, 1)]
+        [TestCase(2U, 2U, 1.0f, 2.0f, 1, 1)] // 1.0 and 2.0f considered inside the 1 tile
+        public void TestGivenTileInGrid_GetTileContainingWorldPosition_ReturnsCoordinate(
+            uint numTilesX, uint numTilesY, float x, float y, int expectedCoordX, int expectedCoordY) {
+            IGrid grid = Substitute.For<IGrid>();
+            grid.NumTilesX.Returns(numTilesX);
+            grid.NumTilesY.Returns(numTilesY);
+            grid.TileSize.Returns((uint)1);
+            grid.OriginWorldPosition.Returns(new Vector2(0, 0));
+            
+            IGridPositionCalculator gridPositionCalculator = new GridPositionCalculator();
+            IntVector2? position = gridPositionCalculator.GetTileContainingWorldPosition(grid, new Vector2(x, y));
+            Assert.NotNull(position);
+            Assert.AreEqual(IntVector2.Of(expectedCoordX, expectedCoordY), position);
+        }
+        
+        [TestCase(4U, 4U, 4.01f, 4.01f)]
+        [TestCase(4U, 4U, -0.01f, -0.01f)]
+        [TestCase(1U, 1U, 1.01f, 1.01f)]
+        [TestCase(1U, 1U, -0.01f, -0.01f)]
+        [TestCase(63U, 23U, -5.0f, 23.5f)]
+        [TestCase(2U, 2U, 2.0001f, 2.00001f)]
+        public void TestGivenTileNotInGrid_GetTileContainingWorldPosition_ReturnsNull(uint numTilesX, uint numTilesY, float x, float y) {
+            IGrid grid = Substitute.For<IGrid>();
+            grid.NumTilesX.Returns(numTilesX);
+            grid.NumTilesY.Returns(numTilesY);
+            grid.TileSize.Returns((uint)1);
+            
+            IGridPositionCalculator gridPositionCalculator = new GridPositionCalculator();
+            Assert.IsNull(gridPositionCalculator.GetTileContainingWorldPosition(grid, new Vector2(x, y)));
+        }
+    }
+}

--- a/Assets/Scripts/Grid/Positioning/Tests/GridPositionCalculatorTest.cs.meta
+++ b/Assets/Scripts/Grid/Positioning/Tests/GridPositionCalculatorTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9e946ba7ace149349b9b31752bb1642f
+timeCreated: 1552257408

--- a/Assets/Scripts/Grid/Serialized/GridData.cs
+++ b/Assets/Scripts/Grid/Serialized/GridData.cs
@@ -1,3 +1,4 @@
+using JetBrains.Annotations;
 using UnityEngine;
 
 namespace Grid.Serialized {
@@ -17,6 +18,18 @@ namespace Grid.Serialized {
         public uint NumTilesY {
             get {
                 return numTilesY;
+            }
+        }
+
+        public bool centeredAtWorldZero;
+        public Vector2 originWorldPosition;
+        public Vector2? OriginWorldPosition {
+            get {
+                if (centeredAtWorldZero) {
+                    return null;
+                }
+
+                return originWorldPosition;
             }
         }
     }

--- a/Assets/Scripts/Grid/Serialized/IGridData.cs
+++ b/Assets/Scripts/Grid/Serialized/IGridData.cs
@@ -1,6 +1,21 @@
+
+using UnityEngine;
+
 namespace Grid.Serialized {
     public interface IGridData {
+        /// <summary>
+        /// Number of tiles in the X axis.
+        /// </summary>
         uint NumTilesX { get; }
+        /// <summary>
+        /// Number of tiles in the Y axis.
+        /// </summary>
         uint NumTilesY { get; }
+        /// <summary>
+        /// If specified, the grid's origin will be set to this world position.
+        /// If not specified, the grid's origin will be (-NumTilesX / 2.0f, -NumTilesY / 2.0f).
+        /// e.g: The grid will have it's Center at 0, 0 by default.
+        /// </summary>
+        Vector2? OriginWorldPosition { get; }
     }
 }


### PR DESCRIPTION
- Add a method to find the tile containing a given point in world space coordinates, or null if the grid does not contain such point.
- Grid can now be centered at world 0, 0, or have a custom origin world position.
