### PR TITLE
Move units inbetween sections

### DIFF
--- a/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -131,7 +131,7 @@ MonoBehaviour:
         m_SerializedData:
         - m_AssemblyName: mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
           m_ClassName: System.Int32
-          m_Data: 59083
+          m_Data: 58430
           m_Key: HostingServicePort
         - m_AssemblyName: mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
           m_ClassName: System.String

--- a/Assets/Scripts/CommandSystem/ICommandFactory.cs
+++ b/Assets/Scripts/CommandSystem/ICommandFactory.cs
@@ -6,4 +6,11 @@ namespace CommandSystem {
     public interface ICommandFactory {
         ICommand Create(Type type, Type dataType, ISerializable data);
     }
+
+    public static class CommandFactoryExtensions {
+        public static ICommand Create<TCommand, TData>(this ICommandFactory commandFactory, TData data)
+            where TData : ISerializable {
+            return commandFactory.Create(typeof(TCommand), typeof(TData), data);
+        }
+    }
 }

--- a/Assets/Scripts/Grid/Commands/GridUnitCommandsInstaller.cs
+++ b/Assets/Scripts/Grid/Commands/GridUnitCommandsInstaller.cs
@@ -10,6 +10,7 @@ namespace Grid.Commands {
             // We expose the concrete type so it can be instantiated by Type.
             Container.Bind<MoveUnitCommand>().AsSingle();
             Container.Bind<RotateUnitCommand>().AsSingle();
+            Container.Bind<MoveUnitSectionCommand>().AsTransient();
             
             // For now, let RotateUnitCommand modify the unit transform directly, but this should go through
             // GridUnitManager which should be the only actor modifying it.

--- a/Assets/Scripts/Grid/Commands/MoveUnitSectionCommand.cs
+++ b/Assets/Scripts/Grid/Commands/MoveUnitSectionCommand.cs
@@ -65,13 +65,11 @@ namespace Grid.Commands {
                 _commandFactory.Create<DespawnUnitCommand, DespawnUnitData>(new DespawnUnitData(_data.unitId));
             _despawnCommand.Run();
 
-            ICommand loadMapSectionCommand = _commandFactory.Create(typeof(LoadMapSectionCommand),
-                                                                    typeof(LoadMapSectionCommandData),
-                                                                    new LoadMapSectionCommandData(_data.toSectionIndex,
-                                                                                                  new
-                                                                                                      LoadMapCommandData(_mapStoreId
-                                                                                                                             .index)));
-            Subject<Unit> sectionLoadedSubject = new Subject<Unit>();
+            var sectionLoadedSubject = new Subject<Unit>();
+            var commandData =
+                new LoadMapSectionCommandData(_data.toSectionIndex, new LoadMapCommandData(_mapStoreId.index));
+            ICommand loadMapSectionCommand =
+                _commandFactory.Create<LoadMapSectionCommand, LoadMapSectionCommandData>(commandData);
             loadMapSectionCommand.Run().Subscribe(_ => {
                 // We need to wait 1 frame in order to avoid race conditions between listeners on new section
                 Observable.IntervalFrame(1).First().Subscribe(__ => {
@@ -79,12 +77,10 @@ namespace Grid.Commands {
                         _entryTileFinder.GetEntryTile(_data.toSectionIndex, _data.fromSectionIndex);
                     // We don't spawn pets (which also are not despawn on despawn command)
                     var unitCommandData = new UnitCommandData(unit.UnitId, unitIndex.Value, unit.UnitData.UnitType);
-                    _spawnCommand = _commandFactory.Create(typeof(SpawnUnitCommand),
-                                                           typeof(SpawnUnitData),
-                                                           new SpawnUnitData(unitCommandData,
-                                                                             entryTileCoords,
-                                                                             isInitialSpawn: false));
+                    var spawnUnitData = new SpawnUnitData(unitCommandData, entryTileCoords, isInitialSpawn: false);
+                    _spawnCommand = _commandFactory.Create<SpawnUnitCommand, SpawnUnitData>(spawnUnitData);
                     _spawnCommand.Run();
+                    
                     sectionLoadedSubject.OnNext(Unit.Default);
                 });
             });

--- a/Assets/Scripts/Grid/Commands/MoveUnitSectionCommand.cs.meta
+++ b/Assets/Scripts/Grid/Commands/MoveUnitSectionCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 21e3f2f5befb45659166a05c12291780
+timeCreated: 1581198534

--- a/Assets/Scripts/Grid/Commands/MoveUnitSectionCommandData.cs
+++ b/Assets/Scripts/Grid/Commands/MoveUnitSectionCommandData.cs
@@ -1,0 +1,24 @@
+using System.Runtime.Serialization;
+using Units;
+
+namespace Grid.Commands {
+    public class MoveUnitSectionCommandData : ISerializable {
+        public readonly UnitId unitId;
+        public readonly uint fromSectionIndex;
+        public readonly uint toSectionIndex;
+
+        #region ISerializable
+        public MoveUnitSectionCommandData(SerializationInfo info, StreamingContext context) {
+            unitId = (UnitId) info.GetValue("unitId", typeof(UnitId));
+            fromSectionIndex = (uint) info.GetInt32("fromSectionIndex");
+            toSectionIndex = (uint) info.GetInt32("toSectionIndex");
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context) {
+            info.AddValue("unitId", unitId);
+            info.AddValue("fromSectionIndex", fromSectionIndex);
+            info.AddValue("toSectionIndex", toSectionIndex);
+        }
+        #endregion
+    }
+}

--- a/Assets/Scripts/Grid/Commands/MoveUnitSectionCommandData.cs
+++ b/Assets/Scripts/Grid/Commands/MoveUnitSectionCommandData.cs
@@ -1,11 +1,19 @@
+using System;
 using System.Runtime.Serialization;
 using Units;
 
 namespace Grid.Commands {
+    [Serializable]
     public class MoveUnitSectionCommandData : ISerializable {
         public readonly UnitId unitId;
         public readonly uint fromSectionIndex;
         public readonly uint toSectionIndex;
+
+        public MoveUnitSectionCommandData(UnitId unitId, uint fromSectionIndex, uint toSectionIndex) {
+            this.unitId = unitId;
+            this.fromSectionIndex = fromSectionIndex;
+            this.toSectionIndex = toSectionIndex;
+        }
 
         #region ISerializable
         public MoveUnitSectionCommandData(SerializationInfo info, StreamingContext context) {

--- a/Assets/Scripts/Grid/Commands/MoveUnitSectionCommandData.cs.meta
+++ b/Assets/Scripts/Grid/Commands/MoveUnitSectionCommandData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2f1be78e6d444e4b97fcb64e58ed8244
+timeCreated: 1581213389

--- a/Assets/Scripts/Map/MapSections/IMapSectionEntryTileFinder.cs
+++ b/Assets/Scripts/Map/MapSections/IMapSectionEntryTileFinder.cs
@@ -1,0 +1,7 @@
+using Math;
+
+namespace Map.MapSections {
+    public interface IMapSectionEntryTileFinder {
+        IntVector2 GetEntryTile(uint sectionIndex, uint fromSectionIndex);
+    }
+}

--- a/Assets/Scripts/Map/MapSections/IMapSectionEntryTileFinder.cs.meta
+++ b/Assets/Scripts/Map/MapSections/IMapSectionEntryTileFinder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 440950fdbb1f4baea780fd676b5dfb29
+timeCreated: 1581218692

--- a/Assets/Scripts/Map/MapSections/MapSectionEntryTileFinder.cs
+++ b/Assets/Scripts/Map/MapSections/MapSectionEntryTileFinder.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using Logging;
+using Map.MapData;
+using Map.MapData.TileMetadata;
+using Math;
+
+namespace Map.MapSections {
+    public class MapSectionEntryTileFinder : IMapSectionEntryTileFinder {
+        private readonly IMapData _mapData;
+        private readonly ILogger _logger;
+
+        public MapSectionEntryTileFinder(IMapData mapData, ILogger logger) {
+            _mapData = mapData;
+            _logger = logger;
+        }
+
+        public IntVector2 GetEntryTile(uint sectionIndex, uint fromSectionIndex) {
+            if (_mapData.Sections.Length <= sectionIndex) {
+                _logger.LogError(LoggedFeature.Map, "Section index not in map: {0}", sectionIndex);
+                return default;
+            }
+
+            IMapSectionData mapSectionData = _mapData.Sections[sectionIndex];
+            var kvp =
+                mapSectionData.TileMetadataMap
+                              .FirstOrDefault(x => x.Value.SectionConnection != null &&
+                                                   x.Value.SectionConnection.Value == fromSectionIndex);
+            if (kvp.Value == null) {
+                _logger.Log(LoggedFeature.Map, "No section connections found: {0}", sectionIndex);
+                return default;
+            }
+
+            return kvp.Key;
+        }
+    }
+}

--- a/Assets/Scripts/Map/MapSections/MapSectionEntryTileFinder.cs.meta
+++ b/Assets/Scripts/Map/MapSections/MapSectionEntryTileFinder.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5ed46bef3f9345a9aa00d6a95824032c
+timeCreated: 1581227038

--- a/Assets/Scripts/Map/MapSections/MapSectionsInstaller.cs
+++ b/Assets/Scripts/Map/MapSections/MapSectionsInstaller.cs
@@ -1,4 +1,5 @@
 using CommandSystem.Installers;
+using Grid.GridUnits;
 using Map.MapSections.Commands;
 using Map.MapSections.UI;
 using UnityEngine;
@@ -15,7 +16,7 @@ namespace Map.MapSections {
                      .AsSingle()
                      .NonLazy();
             Container.Bind<IMapSectionEntryTileFinder>().To<MapSectionEntryTileFinder>().AsSingle();
-            
+
             CommandsInstaller.Install<MapSectionsCommandsInstaller>(Container);
         }
     }

--- a/Assets/Scripts/Map/MapSections/MapSectionsInstaller.cs
+++ b/Assets/Scripts/Map/MapSections/MapSectionsInstaller.cs
@@ -14,6 +14,7 @@ namespace Map.MapSections {
                      .FromComponentInNewPrefab(_mapSelectionViewController)
                      .AsSingle()
                      .NonLazy();
+            Container.Bind<IMapSectionEntryTileFinder>().To<MapSectionEntryTileFinder>().AsSingle();
             
             CommandsInstaller.Install<MapSectionsCommandsInstaller>(Container);
         }

--- a/Assets/Scripts/Map/MapSections/Units.meta
+++ b/Assets/Scripts/Map/MapSections/Units.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44d7d687587c40a0ba35fd9ac6372286
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TileVisibility/TileVisibilityUpdater.cs
+++ b/Assets/Scripts/TileVisibility/TileVisibilityUpdater.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Grid;
+using Grid.Commands;
 using Grid.Positioning;
 using Math;
 using Units;
@@ -48,7 +49,7 @@ namespace TileVisibility {
             _gridUnitManager.UnitPlacedAtTile -= HandleUnitPlacedAtTile;
             _gridUnitManager.UnitRemovedFromTile -= HandleUnitRemovedFromTile;
         }
-
+        
         private void HandleUnitPlacedAtTile(IUnit unit, IntVector2 tileCoords) {
             IntVector2[] visibileTiles =
                 _gridPositionCalculator.GetTilesAtDistance(tileCoords, unit.UnitData.UnitStats.visibilityRadius / 5);

--- a/Assets/Scripts/Units/Movement/ActionHandlers/UnitDragAndDropHandler.cs
+++ b/Assets/Scripts/Units/Movement/ActionHandlers/UnitDragAndDropHandler.cs
@@ -72,10 +72,16 @@ namespace Units.Movement.ActionHandlers {
         }
 
         public void HandleActionConfirmed(IUnit unit) {
-            // These can be checked (throw exception if null) because our stream guarantees that they are not.
+            // This can be checked (throw exception if null) because our stream guarantees that they are not.
             IntVector2 unitCoords = _gridUnitManager.GetUnitCoords(unit).GetValueChecked();
-            IntVector2 mouseCoords = _gridInputManager.TileAtMousePosition.GetValueChecked();
-            CommitUnitMovement(unit, mouseCoords - unitCoords);
+            IntVector2? mouseCoords = _gridInputManager.TileAtMousePosition;
+            if (mouseCoords == null) {
+                // TODO: Maybe we want to commit the tile the unit is at instead?
+                HandleActionCanceled(unit);
+                return;
+            }
+            
+            CommitUnitMovement(unit, mouseCoords.Value - unitCoords);
 
             _disposable?.Dispose();
             _disposable = null;

--- a/Assets/Scripts/Units/Movement/MapSectionUnitMover.cs
+++ b/Assets/Scripts/Units/Movement/MapSectionUnitMover.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using CommandSystem;
+using Grid;
+using Grid.Commands;
+using Map.MapData;
+using Math;
+using UniRx.Async;
+using Zenject;
+
+namespace Units.Movement {
+    public class MapSectionUnitMover : IInitializable, IDisposable {
+        private readonly IGridUnitManager _gridUnitManager;
+        private readonly IMapSectionData _mapSectionData;
+        private readonly ICommandQueue _commandQueue;
+        private static readonly HashSet<UnitId> _unitsOnCooldown = new HashSet<UnitId>();
+
+        public MapSectionUnitMover(IGridUnitManager gridUnitManager,
+                                   IMapSectionData mapSectionData,
+                                   ICommandQueue commandQueue) {
+            _gridUnitManager = gridUnitManager;
+            _mapSectionData = mapSectionData;
+            _commandQueue = commandQueue;
+        }
+
+        public void Initialize() {
+            _gridUnitManager.UnitPlacedAtTile += HandleUnitPlacedAtTile;
+        }
+
+        public void Dispose() {
+            _gridUnitManager.UnitPlacedAtTile -= HandleUnitPlacedAtTile;
+        }
+
+        private async void HandleUnitPlacedAtTile(IUnit unit, IntVector2 tileCoords) {
+            if (!_mapSectionData.TileMetadataMap.ContainsKey(tileCoords)) {
+                return;
+            }
+
+            if (_mapSectionData.TileMetadataMap[tileCoords].SectionConnection == null) {
+                return;
+            }
+
+            // Avoid moving the same unit more than once in a few frames.
+            // This is so we don't move a unit to a new section, then immediately back to the original one.
+            if (_unitsOnCooldown.Contains(unit.UnitId)) {
+                return;
+            }
+
+            _unitsOnCooldown.Add(unit.UnitId);
+            uint sectionIndex = _mapSectionData.TileMetadataMap[tileCoords].SectionConnection.Value;
+            var commandData = new MoveUnitSectionCommandData(unit.UnitId,
+                                                             _mapSectionData.SectionIndex,
+                                                             sectionIndex);
+            _commandQueue.Enqueue<MoveUnitSectionCommand, MoveUnitSectionCommandData>(commandData,
+                                                                                      CommandSource.Game);
+            await UniTask.Delay(TimeSpan.FromMilliseconds(500));
+            _unitsOnCooldown.Remove(unit.UnitId);
+        }
+    }
+}

--- a/Assets/Scripts/Units/Movement/MapSectionUnitMover.cs.meta
+++ b/Assets/Scripts/Units/Movement/MapSectionUnitMover.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 68f72be451fd4a239d80a2e5486fda01
+timeCreated: 1581227699

--- a/Assets/Scripts/Units/Movement/UnitMovementInstaller.cs
+++ b/Assets/Scripts/Units/Movement/UnitMovementInstaller.cs
@@ -17,13 +17,16 @@ namespace Units.Movement {
             Container.Bind(typeof(ISingleUnitActionHandler), typeof(IBatchedUnitActionHandler))
                      .To<UnitDragAndDropHandler>()
                      .AsSingle();
-            
                         
             // UnitDragAndDropHandler modifies transform to preview unit location.
             Container.Bind<IUnitTransformRegistry>()
                      .To<UnitRegistry>()
                      .FromResolve()
                      .WhenInjectedInto<UnitDragAndDropHandler>();
+            
+                        
+            // Handles moving units from one section to another when needed.
+            Container.BindInterfacesTo<MapSectionUnitMover>().AsSingle();
         }
     }
 }

--- a/Assets/Scripts/Units/Spawning/Commands/DespawnUnitCommand.cs
+++ b/Assets/Scripts/Units/Spawning/Commands/DespawnUnitCommand.cs
@@ -54,6 +54,7 @@ namespace Units.Spawning.Commands {
             _tileCoords = _gridUnitManager.GetUnitCoords(_unit);
 
             // Only despawn the unit. This does not remove pet units.
+            _logger.Log(LoggedFeature.Units, "Despawning: {0}", _unit.UnitId);
             _unitPool.Despawn(_unit.UnitId);
             _gridUnitManager.RemoveUnit(_unit);
 

--- a/Assets/Scripts/Units/Spawning/Commands/SpawnUnitCommand.cs
+++ b/Assets/Scripts/Units/Spawning/Commands/SpawnUnitCommand.cs
@@ -20,11 +20,7 @@ namespace Units.Spawning.Commands {
         private readonly IUnitPool _unitPool;
         private readonly ILogger _logger;
 
-        public bool IsInitialGameStateCommand {
-            get {
-                return _data.isInitialSpawn;
-            }
-        }
+        public bool IsInitialGameStateCommand => _data.isInitialSpawn;
 
         public SpawnUnitCommand(SpawnUnitData data,
                                 ICommandFactory commandFactory,
@@ -52,7 +48,6 @@ namespace Units.Spawning.Commands {
             }
 
             IUnitData unitData = unitDatas[(int) _data.unitCommandData.UnitIndex];
-            _logger.Log(LoggedFeature.Units, "Spawning: {0}", unitData.Name);
 
             // First, spawn the pets recursively.
             // We create commands that we execute directly, because
@@ -71,6 +66,7 @@ namespace Units.Spawning.Commands {
             IUnit unit = _unitPool.Spawn(_data.unitCommandData.unitId, unitData, pets);
             _gridUnitManager.PlaceUnitAtTile(unit, _data.tileCoords);
 
+            _logger.Log(LoggedFeature.Units, "Spawned: {0}. Id: {1}", unitData.Name, unit.UnitId);
             return Observable.ReturnUnit();
         }
 

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -216,8 +216,4 @@ QualitySettings:
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
     excludedTargetPlatforms: []
-  m_PerPlatformDefaultQuality:
-    Android: 0
-    Standalone: 0
-    WebGL: 0
-    iPhone: 0
+  m_PerPlatformDefaultQuality: {}


### PR DESCRIPTION
Adds automatic section movement when moving to a section gate.
Ability to spawn units in map too. This allows manually moving units to different sections.

Fixes #70 